### PR TITLE
Add missing checkout step to build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
     docker:
       - image: node:11.9.0
     steps:
+      - checkout
       - attach_workspace:
           at: .
       - run:


### PR DESCRIPTION
* Add "checkout" to gh-pages step in build pipeline - gh-pages npm package requires a git directory