### PR TITLE
Add extra config for working with gh-pages feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Disable GitHub Jekyll builds
+          command: touch public/.nojekyll
+      - run:
           name: Install and configure dependencies
           command: |
             npm install -g --silent gh-pages@2.0.1
@@ -30,7 +33,7 @@ jobs:
             - "df:2f:bb:e8:16:52:04:e3:0a:8f:12:d7:2c:32:17:ae"
       - run:
           name: Deploy docs to gh-pages
-          command: gh-pages --dist public
+          command: gh-pages --dotfiles --message "[skip ci] gh-pages update" --dist public
 
 workflows:
   version: 2.1


### PR DESCRIPTION
* Add .nojekyll file to prevent GitHub's built-in Jekyll engine running
* Add skip to gh-pages commits to prevent CircleCI builds on branch