### PR TITLE
docs(proteus): Remove team member; readiness probe

### DIFF
--- a/docs/teams/proteus.md
+++ b/docs/teams/proteus.md
@@ -9,7 +9,6 @@ Team Proteus is a delivery team currently working on the Data Platform. The team
 - Sean Siford - Senior Software Engineer
 - Alex Bush - Senior Software Engineer
 - Benjamin Morgan - Software Engineer
-- Andy Pickin - Software Engineer
 - Kevin Harragan - Software Engineer
 - Andy Cleveland - Test Engineer
 - Chris Sutcliffe - DevOps Engineer
@@ -45,8 +44,8 @@ Our definition of done must be followed for all work delivered. Sections may onl
 - Appropriate unit/component tests written, passing and executed in build pipeline
 
 ### Container Apps
-- [POST-AB#6335] Should have readiness probe
-- [POST-AB#6349] Should expose appropriate monitoring endpoints
+- Should have readiness probe
+- Should expose appropriate monitoring endpoints
 - Logging out to appropriate log service
 - App deployment written and deployed by Flux
 - Context paths in container context and rewrite rules in ingresses


### PR DESCRIPTION
* Remove team member that has left
* Remove PBI tag on readiness probes
* Remove PBI tag on monitoring endpoints