### PR TITLE
CI needs to point back to master branch

### DIFF
--- a/.github/workflows/markdown-ci.yml
+++ b/.github/workflows/markdown-ci.yml
@@ -2,9 +2,9 @@ name: Markdown CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/markdown-ci.yml
+++ b/.github/workflows/markdown-ci.yml
@@ -2,9 +2,9 @@ name: Markdown CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main, master ]
   pull_request:
-    branches: [ master ]
+    branches: [ main, master ]
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+      "test-alex": "alex"
+    },
+    "dependencies": {
+      "alex": "^9.0.1"
+    }
+}


### PR DESCRIPTION
Went to test this and remembered we are still on `master`, whereas I wrote the CI `yml` on my repo with a default of `main`.

Changing it to `master` for the time being.

Also adding missing package.json. The perils of lift and shift from testing it elsewhere! :)