### PR TITLE
Refine initial markdown CI workflow

### DIFF
--- a/.github/workflows/markdown-ci.yml
+++ b/.github/workflows/markdown-ci.yml
@@ -24,14 +24,12 @@ jobs:
         if: success() || failure()
         uses: nosborn/github-action-markdown-cli@v1.1.1
         with:
-          # config_file: # optional
           files: .
           ignore_files: node_modules
-          # rules: # optional
+          config_file: "mdlint.json"
 
       - name: Check for 404 links      
         if: success() || failure() 
         uses: restqa/404-links@1.0.0
         with:
           path: .
-          # ignore: # optional, default is          

--- a/mdlint.json
+++ b/mdlint.json
@@ -1,0 +1,13 @@
+{
+    "comment": "Relaxed rules",
+  
+    "default": true,
+    "whitespace": false,
+    "line_length": false,
+    "ul-start-left": false,
+    "ul-indent": false,
+    "no-inline-html": false,
+    "no-bare-urls": false,
+    "fenced-code-language": false,
+    "first-line-h1": false
+  }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,23 @@
 {
   "scripts": {
-      "test-alex": "alex"
-    },
-    "dependencies": {
-      "alex": "^9.0.1"
-    }
+    "test-alex": "alex"
+  },
+  "dependencies": {
+    "alex": "^9.0.1"
+  },
+  "alex": {
+    "noBinary": false,
+    "profanitySureness": 2,
+    "deny": [
+      "blacklist", 
+      "blacklisted", 
+      "blacklisting", 
+      "whitelist",
+      "whitelisting",
+      "whitelisted",
+      "whitespace",
+      "sanity-check",
+      "dummy"
+    ]
+  }
 }


### PR DESCRIPTION
See #115

### Relaxed markdown linting rules 

This repository is quite mature and gone unchecked; the number of warnings is a little overwhelming.

### Reduced Alex.js inclusive language sensitivity to a minimum starting point

- Checks for gendered wording off
- Lowest sensitivity level for profanity (doesn't highlight 'UK' now)
- Set it to allow everything and deny the following **rules** (not words):

```json
"deny": [
      "blacklist", 
      "blacklisted", 
      "blacklisting", 
      "whitelist",
      "whitelisting",
      "whitelisted",
      "whitespace",
      "sanity-check",
      "dummy"
    ]
```

Alex.js sits on top of retext-equality, amongst other things. It's very easy to contribute new rules. I added _dummy_ just today: https://github.com/retextjs/retext-equality/pull/103
