### PR TITLE
Removing ref to Inner Source repository

### DIFF
--- a/software-engineering-policies/CodeReuse/CodeReusePolicy.md
+++ b/software-engineering-policies/CodeReuse/CodeReusePolicy.md
@@ -10,5 +10,3 @@ Lead Engineers are accountable for effective:
 ## Verification
 
 Teams should be seen to be actively using shared assets
-
-The assets that teams push to the UKHO InnerSource repository, with adequate test and documentation artefacts, are available for inspection.


### PR DESCRIPTION
Inner source repo does not exist. Reference to this has been removed from the Code Reuse Policy document.