### PR TITLE
Update node version as Node.js 12 depreciated (#219)

### DIFF
--- a/.github/workflows/markdown-ci.yml
+++ b/.github/workflows/markdown-ci.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '12'  
       - run: npm install alex


### PR DESCRIPTION
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-node@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.