### PR TITLE
Add initial Threat Modelling document

### DIFF
--- a/security/ThreatModelling/ThreatModelling.md
+++ b/security/ThreatModelling/ThreatModelling.md
@@ -15,8 +15,8 @@ By performing threat modelling, we shift security practices left within the soft
 > [!TIP]
 > The 3 laws of OPSEC
 >
-> 1.	If you don’t know the threat, how do you know what to protect.
-> 2.	If you don’t know what to protect, how do you know you’re protecting it.
+> 1.	If you don’t know the threat, how do you know what to protect?
+> 2.	If you don’t know what to protect, how do you know you’re protecting it?
 > 3.	If you are not protecting it, the dragon wins. 
 
 ## What is Threat Modelling

--- a/security/ThreatModelling/ThreatModelling.md
+++ b/security/ThreatModelling/ThreatModelling.md
@@ -84,7 +84,7 @@ The actions are as follows:
 - __Transfer__ - Transfer risk to an insurer or customer.
 
 >[!NOTE]
->Any documentation around threat modelling should not be stored in a public >domain. As an effort to provide a secure and robust service to our users, we do >not want to expose any potential weaknesses to bad actors. 
+>Any documentation around threat modelling should not be stored in a public domain. As an effort to provide a secure and robust service to our users, we do not want to expose any potential weaknesses to bad actors. 
 
 ## Training
 

--- a/security/ThreatModelling/ThreatModelling.md
+++ b/security/ThreatModelling/ThreatModelling.md
@@ -19,7 +19,7 @@ By performing threat modelling, we shift security practices left within the soft
 > 2.	If you don’t know what to protect, how do you know you’re protecting it.
 > 3.	If you are not protecting it, the dragon wins. 
 
-## What is threat modelling?
+## What is threat modelling
 
 At its basic, threat modelling is identifying and prioritizing potential attacks, threats, and vulnerabilities within your assets. This is done by identifying assets utilising methods such as data flow diagrams to help discuss scenarios, surface areas and counter measures. 
 

--- a/security/ThreatModelling/ThreatModelling.md
+++ b/security/ThreatModelling/ThreatModelling.md
@@ -1,0 +1,84 @@
+# Threat Modelling in the UKHO
+
+## Why do we practice threat modelling?
+
+As we develop our applications and try to provide a service to our users, there will always be malicious actors that will try to access any data we hold or just try to circumnavigate our controls for fun. Whilst our frameworks and techniques become more advanced, so do the attackers and this is why we must always ask the questions. 
+
+Our aim to try and adhere to the CIA triad:
+
+- __Confidentiality__: Only authorised users and processes may access or modify the data it is allow to
+
+- __Integrity__: Data should be maintained in a correct state and nothing or nobody should be able to improperly modify or delete it, either accidentally or maliciously
+
+- __Availability__: Authorised users should be able to access data whenever they need to.
+
+By performing threat modelling, we shift security practices left within the software development lifecycle which helps promote catching issues earlier in process when the cost is lower. Whilst it has a security benefit, there is a business benefit due to the return on investment by doing this whilst the cost of an issue is low. 
+
+> [!INFORMATION]
+> The 3 laws of OPSEC
+> 1.	If you don’t know the threat, how do you know what to protect.
+> 2.	If you don’t know what to protect, how do you know you’re protecting it.
+> 3.	If you are not protecting it, the dragon wins. 
+
+## What is threat modelling?
+
+At its basic, threat modelling is identifying and prioritizing potential attacks, threats, and vulnerabilities within your assets. This is done by identifying assets utilising methods such as data flow diagrams to help discuss scenarios, surface areas and counter measures. 
+
+There are different approaches and methodologies to threat modelling that help support different operational functions. Approaches help support the methodology chosen and neither are used in isolation. 
+
+### Approaches
+- Asset based – Best to describe assets when working with multi disciplined team.
+- Attacker based – Best used when working with experienced security team members.
+- Application based – ideal when the team is made up of mostly developers.
+
+### Methodologies.
+- PASTA – Process Attack Simulation and Threat Analysis
+- STRIDE – Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege
+- OCTAVE – Operationally Critical Threat, Asset and Vulnerability Evaluation
+- TRIKE – Risk based security auditing from top level down.
+- VAST – Visual, Agile, Simple Threat modelling
+
+## How do we perform threat modelling
+Threat modelling should be performed at the beginning of a project, to assist with understanding potential attack vectors and allow for designs to be changed before anything is created, or whenever there is a change to the attack surface of the application.
+
+Wherever possible, a data flow diagram should be created to help visualise and define the assets that are apart of the application, so that a conversation can be started about attack vectors of the different areas. The data flow diagram should be a growing diagram that exists alongside the project to maintain knowledge.
+
+To start the conversation, the following will need to be understood so that the session can focus on what is required from the threat modelling:
+- Scope – What is in scope for this session?
+- Stakeholders – Who has input into this system design and needs to be involved in this modelling.
+- Risk management – Who will support you in assessing and devising a plan for any risks that are found.
+
+Depending on the stage of the project, facilitation can be handled in two ways:
+- Early project – Facilitated by Security personnel (Principals, Lead Tech, ITSO)
+- Mature project – Facilitated by team with Security champion/Lead Tech support
+
+All findings that come out of a session should be logged so that if required it can be looked over and verified. This should also serve as a maintenance guide as to what to attack in the case of BAU work if required. Prioritisation of issues are to be discussed with the Product Owner and support can be provided from a Security Champion/Tech Lead.
+
+Questions around the system should utilise the 6 aspects of STRIDE. There can be some crossover with these aspects so wherever possible call out the most prominent one (or if there are indeed multiple aspects for a single issue, log them as such)
+
+|Name |	Meaning | Desired Security Property | Example |
+| --- | ------- | ------------------------- | ------- |
+| Spoofing | Pretending to be another user/system |	Authentication | Unauthenticated API with username header |
+| Tampering	| Modifying data in the application | Integrity | SQL Injection through unvalidated parameters |
+| Repudiation |	Accountability of action | Non-repudiation | Deletion of data with information logged as to who and what. |
+| Information Disclosure | Access of allowed information | Confidentiality  |Bleed of information between users |
+| Denial of Service	| Availability of application |	Availability | Degradation of service due to high volumes of requests |
+| Elevation of Privilege | Access to the right privileged information | Authorization | Ability to self-promote to admin via a unvalidated parameter |
+
+Any issues found will need an action assigning to it with an action owner. This owner is accountable for chasing up the issue and not responsible for the issue. 
+
+The actions are as follows:
+- __Accept__ - decide that the business impact is acceptable, and document who has chosen to accept the risk.
+- __Eliminate__ - remove components that make the vulnerability possible.
+- __Mitigate__ - add checks or controls that reduce risk impact, or the chances of occurrence. This should have a review date attached to it or an action against it as to help remove the issue. 
+- __Transfer__ - Transfer risk to an insurer or customer.
+
+The tooling of choice to support this is the Microsoft Threat Modelling Tool. Utilising the data flow diagram within the tooling, it can analyse and support the STRIDE method of giving potential attack vectors to your application. This should not be a replacement for the conversation however and such compliment your process. 
+
+>[!NOTE]
+>Any documentation around threat modelling should not be stored in a public >domain. As an effort to provide a secure and robust service to our users, we do >not want to expose any potential weaknesses to bad actors. 
+
+## Training
+- [Threat Modeling Path | Pluralsight]()
+- [Microsoft Threat Modeling Tool overview - Azure | Microsoft Learn]()
+- [Conducting a STRIDE-based threat analysis - GOV.UK (www.gov.uk)]()

--- a/security/ThreatModelling/ThreatModelling.md
+++ b/security/ThreatModelling/ThreatModelling.md
@@ -14,7 +14,7 @@ Our aim to try and adhere to the CIA triad:
 
 By performing threat modelling, we shift security practices left within the software development lifecycle which helps promote catching issues earlier in process when the cost is lower. Whilst it has a security benefit, there is a business benefit due to the return on investment by doing this whilst the cost of an issue is low. 
 
-> [!INFORMATION]
+> [!TIP]
 > The 3 laws of OPSEC
 > 1.	If you don’t know the threat, how do you know what to protect.
 > 2.	If you don’t know what to protect, how do you know you’re protecting it.

--- a/security/ThreatModelling/ThreatModelling.md
+++ b/security/ThreatModelling/ThreatModelling.md
@@ -2,15 +2,15 @@
 
 ## Why do we practice threat modelling
 
-As we develop our applications and try to provide a service to our users, there will always be malicious actors that will try to access any data we hold or just try to circumnavigate our controls for fun. Whilst our frameworks and techniques become more advanced, so do the attackers and this is why we must always ask the questions. 
+As we develop our applications and try to provide a service to our users, there will always be malicious actors who will try to access any data we hold, or just try to circumnavigate our controls for fun. Whilst our frameworks and techniques become more advanced, so do the attackers - so this is why we must always ask these questions.  
 
 Our aim to try and adhere to the CIA triad:
 
-- __Confidentiality__: Only authorised users and processes may access or modify the data it is allow to
-- __Integrity__: Data should be maintained in a correct state and nothing or nobody should be able to improperly modify or delete it, either accidentally or maliciously
+- __Confidentiality__: Only authorised users and processes may access or modify the data it is allowed to.
+- __Integrity__: Data should be maintained in a correct state, and nothing or nobody should be able to improperly modify or delete it - whether accidentally or maliciously.
 - __Availability__: Authorised users should be able to access data whenever they need to.
 
-By performing threat modelling, we shift security practices left within the software development lifecycle which helps promote catching issues earlier in process when the cost is lower. Whilst it has a security benefit, there is a business benefit due to the return on investment by doing this whilst the cost of an issue is low. 
+By performing threat modelling, we shift security practices left within the software development lifecycle, which will help us catch issues earlier in process when the cost is lower. Whilst there is a security benefit, there is also a business benefit as well due to the return on investment by doing this whilst the cost of an issue is low.  
 
 > [!TIP]
 > The 3 laws of OPSEC
@@ -19,37 +19,42 @@ By performing threat modelling, we shift security practices left within the soft
 > 2.	If you don’t know what to protect, how do you know you’re protecting it.
 > 3.	If you are not protecting it, the dragon wins. 
 
-## What is threat modelling
+## What is Threat Modelling
 
-At its basic, threat modelling is identifying and prioritizing potential attacks, threats, and vulnerabilities within your assets. This is done by identifying assets utilising methods such as data flow diagrams to help discuss scenarios, surface areas and counter measures. 
+At its most basic level; Threat Modelling is identifying and prioritising potential attacks, threats, and vulnerabilities within your assets. This is done by identifying assets (using methods such as data flow diagrams) to help discuss scenarios, "attack surface" areas, and countermeasures.  
 
-There are different approaches and methodologies to threat modelling that help support different operational functions. Approaches help support the methodology chosen and neither are used in isolation. 
+There are different _approaches_ and _methodologies_ to threat modelling that help support different operational functions. "_Approaches_" help support the "_Methodology_" chosen, and neither are used in isolation.  
 
 ### Approaches
 
-- Asset based – Best to describe assets when working with multi disciplined team.
+- Asset based – Best used to describe assets when working with a multi-disciplinary team.
 - Attacker based – Best used when working with experienced security team members.
-- Application based – ideal when the team is made up of mostly developers.
+- Application based – Best used when working in/with a team made up mostly of developers.
 
 ### Methodologies
 
-- PASTA – Process Attack Simulation and Threat Analysis
-- STRIDE – Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege
-- OCTAVE – Operationally Critical Threat, Asset and Vulnerability Evaluation
-- TRIKE – Risk based security auditing from top level down.
-- VAST – Visual, Agile, Simple Threat modelling
+- __PASTA__ – Process Attack Simulation and Threat Analysis
+- __STRIDE__ – Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege
+- __OCTAVE__ – Operationally Critical Threat, Asset and Vulnerability Evaluation
+- __TRIKE__ – Risk based security auditing from top level down.
+- __VAST__ – Visual, Agile, Simple Threat modelling
 
 ## How do we perform threat modelling
 
-Threat modelling should be performed at the beginning of a project, to assist with understanding potential attack vectors and allow for designs to be changed before anything is created, or whenever there is a change to the attack surface of the application.
+Threat modelling should be performed: 
 
-Wherever possible, a data flow diagram should be created to help visualise and define the assets that are apart of the application, so that a conversation can be started about attack vectors of the different areas. The data flow diagram should be a growing diagram that exists alongside the project to maintain knowledge.
+ - At the beginning of a project - (to assist with understanding potential attack vectors, and allow for designs to be changed before anything is created),
+ - Whenever there is a change to the _attack surface_ of the application.
 
-To start the conversation, the following will need to be understood so that the session can focus on what is required from the threat modelling:
+Wherever possible, a **_Data Flow Diagram_** can be created to help visualise and define the assets that are apart of the application, so that a conversation can be started about attack vectors of the different areas. The data flow diagram should be a growing diagram that is maintained in tandem with the project.
 
-- Scope – What is in scope for this session?
-- Stakeholders – Who has input into this system design and needs to be involved in this modelling.
-- Risk management – Who will support you in assessing and devising a plan for any risks that are found.
+The tooling of choice to support this is the **_Microsoft Threat Modelling Tool_**. Utilising the data flow diagram within the tooling, it can analyse and support the STRIDE method of giving potential attack vectors to your application. This tooling should be a compliment for the _conversation_ however, rather than a replacement for it. 
+
+To start the conversation for a Threat Modelling session, the following will need to be understood so that the session can focus on what is required from the threat modelling:
+
+- __Scope__ – What is in scope for this session?
+- __Stakeholders__ – Who has input into this system design and needs to be involved in this modelling.
+- __Risk management__ – Who will support you in assessing and devising a plan for any risks that are found.
 
 Depending on the stage of the project, facilitation can be handled in two ways:
 
@@ -62,14 +67,14 @@ Questions around the system should utilise the 6 aspects of STRIDE. There can be
 
 |Name |	Meaning | Desired Security Property | Example |
 | --- | ------- | ------------------------- | ------- |
-| Spoofing | Pretending to be another user/system |	Authentication | Unauthenticated API with username header |
-| Tampering	| Modifying data in the application | Integrity | SQL Injection through unvalidated parameters |
-| Repudiation |	Accountability of action | Non-repudiation | Deletion of data with information logged as to who and what. |
-| Information Disclosure | Access of allowed information | Confidentiality  |Bleed of information between users |
-| Denial of Service	| Availability of application |	Availability | Degradation of service due to high volumes of requests |
-| Elevation of Privilege | Access to the right privileged information | Authorization | Ability to self-promote to admin via a unvalidated parameter |
+| __Spoofing__ | Pretending to be another user/system |	Authentication | Unauthenticated API with username header |
+| __Tampering__	| Modifying data in the application | Integrity | SQL Injection through unvalidated parameters |
+| __Repudiation__ |	Accountability of action | Non-repudiation | Deletion of data with information logged as to who and what. |
+| __Information Disclosure__ | Access of allowed information | Confidentiality  |Bleed of information between users |
+| __Denial of Service__	| Availability of application |	Availability | Degradation of service due to high volumes of requests |
+| __Elevation of Privilege__ | Access to the right privileged information | Authorization | Ability to self-promote to admin via a unvalidated parameter |
 
-Any issues found will need an action assigning to it with an action owner. This owner is accountable for chasing up the issue and not responsible for the issue. 
+Any issues found will need an **_Action_** assigned to it (see list below), as well as an **_Action Owner_**. This owner is not _responsible_ for the issue, but it accountable for _chasing up_ the issue.
 
 The actions are as follows:
 
@@ -77,8 +82,6 @@ The actions are as follows:
 - __Eliminate__ - remove components that make the vulnerability possible.
 - __Mitigate__ - add checks or controls that reduce risk impact, or the chances of occurrence. This should have a review date attached to it or an action against it as to help remove the issue. 
 - __Transfer__ - Transfer risk to an insurer or customer.
-
-The tooling of choice to support this is the Microsoft Threat Modelling Tool. Utilising the data flow diagram within the tooling, it can analyse and support the STRIDE method of giving potential attack vectors to your application. This should not be a replacement for the conversation however and such compliment your process. 
 
 >[!NOTE]
 >Any documentation around threat modelling should not be stored in a public >domain. As an effort to provide a secure and robust service to our users, we do >not want to expose any potential weaknesses to bad actors. 

--- a/security/ThreatModelling/ThreatModelling.md
+++ b/security/ThreatModelling/ThreatModelling.md
@@ -1,21 +1,20 @@
 # Threat Modelling in the UKHO
 
-## Why do we practice threat modelling?
+## Why do we practice threat modelling
 
 As we develop our applications and try to provide a service to our users, there will always be malicious actors that will try to access any data we hold or just try to circumnavigate our controls for fun. Whilst our frameworks and techniques become more advanced, so do the attackers and this is why we must always ask the questions. 
 
 Our aim to try and adhere to the CIA triad:
 
 - __Confidentiality__: Only authorised users and processes may access or modify the data it is allow to
-
 - __Integrity__: Data should be maintained in a correct state and nothing or nobody should be able to improperly modify or delete it, either accidentally or maliciously
-
 - __Availability__: Authorised users should be able to access data whenever they need to.
 
 By performing threat modelling, we shift security practices left within the software development lifecycle which helps promote catching issues earlier in process when the cost is lower. Whilst it has a security benefit, there is a business benefit due to the return on investment by doing this whilst the cost of an issue is low. 
 
 > [!TIP]
 > The 3 laws of OPSEC
+>
 > 1.	If you don’t know the threat, how do you know what to protect.
 > 2.	If you don’t know what to protect, how do you know you’re protecting it.
 > 3.	If you are not protecting it, the dragon wins. 
@@ -27,11 +26,13 @@ At its basic, threat modelling is identifying and prioritizing potential attacks
 There are different approaches and methodologies to threat modelling that help support different operational functions. Approaches help support the methodology chosen and neither are used in isolation. 
 
 ### Approaches
+
 - Asset based – Best to describe assets when working with multi disciplined team.
 - Attacker based – Best used when working with experienced security team members.
 - Application based – ideal when the team is made up of mostly developers.
 
-### Methodologies.
+### Methodologies
+
 - PASTA – Process Attack Simulation and Threat Analysis
 - STRIDE – Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege
 - OCTAVE – Operationally Critical Threat, Asset and Vulnerability Evaluation
@@ -39,16 +40,19 @@ There are different approaches and methodologies to threat modelling that help s
 - VAST – Visual, Agile, Simple Threat modelling
 
 ## How do we perform threat modelling
+
 Threat modelling should be performed at the beginning of a project, to assist with understanding potential attack vectors and allow for designs to be changed before anything is created, or whenever there is a change to the attack surface of the application.
 
 Wherever possible, a data flow diagram should be created to help visualise and define the assets that are apart of the application, so that a conversation can be started about attack vectors of the different areas. The data flow diagram should be a growing diagram that exists alongside the project to maintain knowledge.
 
 To start the conversation, the following will need to be understood so that the session can focus on what is required from the threat modelling:
+
 - Scope – What is in scope for this session?
 - Stakeholders – Who has input into this system design and needs to be involved in this modelling.
 - Risk management – Who will support you in assessing and devising a plan for any risks that are found.
 
 Depending on the stage of the project, facilitation can be handled in two ways:
+
 - Early project – Facilitated by Security personnel (Principals, Lead Tech, ITSO)
 - Mature project – Facilitated by team with Security champion/Lead Tech support
 
@@ -68,6 +72,7 @@ Questions around the system should utilise the 6 aspects of STRIDE. There can be
 Any issues found will need an action assigning to it with an action owner. This owner is accountable for chasing up the issue and not responsible for the issue. 
 
 The actions are as follows:
+
 - __Accept__ - decide that the business impact is acceptable, and document who has chosen to accept the risk.
 - __Eliminate__ - remove components that make the vulnerability possible.
 - __Mitigate__ - add checks or controls that reduce risk impact, or the chances of occurrence. This should have a review date attached to it or an action against it as to help remove the issue. 
@@ -79,6 +84,7 @@ The tooling of choice to support this is the Microsoft Threat Modelling Tool. Ut
 >Any documentation around threat modelling should not be stored in a public >domain. As an effort to provide a secure and robust service to our users, we do >not want to expose any potential weaknesses to bad actors. 
 
 ## Training
-- [Threat Modeling Path | Pluralsight]()
-- [Microsoft Threat Modeling Tool overview - Azure | Microsoft Learn]()
-- [Conducting a STRIDE-based threat analysis - GOV.UK (www.gov.uk)]()
+
+- [Threat Modeling Path | Pluralsight](https://app.pluralsight.com/paths/skill/threat-modeling)
+- [Microsoft Threat Modeling Tool overview - Azure | Microsoft Learn](https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool)
+- [Conducting a STRIDE-based threat analysis - GOV.UK (www.gov.uk)](https://www.gov.uk/government/publications/secure-connected-places-playbook-documents/conducting-a-stride-based-threat-analysis)

--- a/software-engineering-policies/SecureDevelopment/SecureDevelopmentPolicy.md
+++ b/software-engineering-policies/SecureDevelopment/SecureDevelopmentPolicy.md
@@ -160,7 +160,7 @@ The risk owner is the person who is responsible for the product. This may be the
 >_Each project will have recurring pieces of functionality. These generic PBI’s should be captured, threat modelled, and code mitigations agreed. OWASP vulnerabilities should be discussed such as XSS, SQL Injections, broken authentication/authorisation, direct object referencing etc. It is easier to review and catch vulnerabilities during code reviews if everyone tackles vulnerabilities with the same techniques._
 
 - Each team must document a set of generic scenarios for their project.
-- The team must follow a threat modelling process.
+- The team must follow a [threat modelling process](../../security/ThreatModelling/ThreatModelling.md).
 - Each team must agree on standard code approaches to mitigate common vulnerabilities.
 - A code review checklist must be generated from the results of threat modelling.
 - Testing criteria must be agreed and recorded within the solution.

--- a/software-engineering-policies/SecureDevelopment/SecureDevelopmentPolicy.md
+++ b/software-engineering-policies/SecureDevelopment/SecureDevelopmentPolicy.md
@@ -157,7 +157,7 @@ The risk owner is the person who is responsible for the product. This may be the
 
 ### Threat Library & Mitigations
 
->_Each project will have recurring pieces of functionality. These generic PBI’s should be captured, threat modelled, and code mitigations agreed. OWASP vulnerabilities should be discussed such as XSS, SQL Injections, broken authentication/authorisation, direct object referencing etc. It is easier to review and catch vulnerabilities during code reviews if everyone tackles vulnerabilities with the same techniques._
+>_Each project will have recurring pieces of functionality. These generic PBIs should be captured, threat-modelled, and have code mitigations agreed. OWASP vulnerabilities should be discussed such as XSS, SQL Injections, broken authentication/authorisation, direct object referencing etc. It is easier to review and catch vulnerabilities during code reviews if everyone tackles vulnerabilities with the same techniques._
 
 - Each team must document a set of generic scenarios for their project.
 - The team must follow a [threat modelling process](../../security/ThreatModelling/ThreatModelling.md).


### PR DESCRIPTION
# What has changed
- Added a Threat Modelling document to try and standardise the UKHO approach
- Linked to the Threat Modelling document from the Secure Development policy

# Why has this changed?
- Provide consistency in approach to Threat Modelling
- Add starting point for discussions on approach
- Enhance work began by existing teams
- Provide documentation for Audit purposes